### PR TITLE
Wire _check_autosave on init

### DIFF
--- a/ipywebrtc/webrtc.py
+++ b/ipywebrtc/webrtc.py
@@ -352,8 +352,9 @@ class ImageRecorder(Recorder):
     def __init__(self, format='png', filename=Undefined, recording=False, autosave=False, **kwargs):
         super(ImageRecorder, self).__init__(
             format=format, filename=filename, recording=recording, autosave=autosave, **kwargs)
-        # Set up initial observer on child:
-        self.image.observe(self._check_autosave, 'value')
+        if 'image' not in kwargs:
+            # Set up initial observer on child:
+            self.image.observe(self._check_autosave, 'value')
 
     @traitlets.default('image')
     def _default_image(self):
@@ -413,8 +414,9 @@ class VideoRecorder(Recorder):
     def __init__(self, format='webm', filename=Undefined, recording=False, autosave=False, **kwargs):
         super(VideoRecorder, self).__init__(
             format=format, filename=filename, recording=recording, autosave=autosave, **kwargs)
-        # Set up initial observer on child:
-        self.video.observe(self._check_autosave, 'value')
+        if 'video' not in kwargs:
+            # Set up initial observer on child:
+            self.video.observe(self._check_autosave, 'value')
 
     @traitlets.default('video')
     def _default_video(self):
@@ -466,8 +468,9 @@ class AudioRecorder(Recorder):
     def __init__(self, format='webm', filename=Undefined, recording=False, autosave=False, **kwargs):
         super(AudioRecorder, self).__init__(
             format=format, filename=filename, recording=recording, autosave=autosave, **kwargs)
-        # Set up initial observer on child:
-        self.audio.observe(self._check_autosave, 'value')
+        if 'audio' not in kwargs:
+            # Set up initial observer on child:
+            self.audio.observe(self._check_autosave, 'value')
 
     @traitlets.default('audio')
     def _default_audio(self):

--- a/ipywebrtc/webrtc.py
+++ b/ipywebrtc/webrtc.py
@@ -7,7 +7,8 @@ except ImportError:
     from urllib.request import urlopen  # py3
 from traitlets import (
     observe,
-    Bool, Bytes, Dict, Instance, Int, List, TraitError, Unicode, validate
+    Bool, Bytes, Dict, Instance, Int, List, TraitError, Unicode, validate,
+    Undefined
 )
 from ipywidgets import DOMWidget, Image, Video, Audio, register, widget_serialization
 from ipython_genutils.py3compat import string_types
@@ -348,6 +349,12 @@ class ImageRecorder(Recorder):
     _width = Unicode().tag(sync=True)
     _height = Unicode().tag(sync=True)
 
+    def __init__(self, format='png', filename=Undefined, recording=False, autosave=False, **kwargs):
+        super(ImageRecorder, self).__init__(
+            format=format, filename=filename, recording=recording, autosave=autosave, **kwargs)
+        # Set up initial observer on child:
+        self.image.observe(self._check_autosave, 'value')
+
     @traitlets.default('image')
     def _default_image(self):
         return Image(width=self._width, height=self._height, format=self.format)
@@ -403,6 +410,12 @@ class VideoRecorder(Recorder):
 
     video = Instance(Video).tag(sync=True, **widget_serialization)
 
+    def __init__(self, format='webm', filename=Undefined, recording=False, autosave=False, **kwargs):
+        super(VideoRecorder, self).__init__(
+            format=format, filename=filename, recording=recording, autosave=autosave, **kwargs)
+        # Set up initial observer on child:
+        self.video.observe(self._check_autosave, 'value')
+
     @traitlets.default('video')
     def _default_video(self):
         return Video(format=self.format, controls=True)
@@ -450,6 +463,12 @@ class AudioRecorder(Recorder):
 
     audio = Instance(Audio).tag(sync=True, **widget_serialization)
 
+    def __init__(self, format='webm', filename=Undefined, recording=False, autosave=False, **kwargs):
+        super(AudioRecorder, self).__init__(
+            format=format, filename=filename, recording=recording, autosave=autosave, **kwargs)
+        # Set up initial observer on child:
+        self.audio.observe(self._check_autosave, 'value')
+
     @traitlets.default('audio')
     def _default_audio(self):
         return Audio(format=self.format, controls=True)
@@ -459,7 +478,7 @@ class AudioRecorder(Recorder):
         self.audio.format = self.format
 
     @observe('audio')
-    def _bind_video(self, change):
+    def _bind_audio(self, change):
         if change.old:
             change.old.unobserve(self._check_autosave, 'value')
         change.new.observe(self._check_autosave, 'value')

--- a/js/src/webrtc.js
+++ b/js/src/webrtc.js
@@ -463,7 +463,7 @@ class RecorderModel extends widgets.DOMWidgetModel {
 
         const mimeType = this.type + '/' + this.get('format');
         if (!MediaRecorder.isTypeSupported(mimeType)) {
-            throw new Error('The mimeType', mimeType, 'is not supported for record on this browser');
+            throw new Error(`The mimeType ${mimeType} is not supported for record on this browser`);
         }
 
         if (this.get('recording')) {

--- a/js/src/webrtc.js
+++ b/js/src/webrtc.js
@@ -150,7 +150,7 @@ class StreamModel extends MediaStreamModel {
                 return this.media.mozCaptureStream();
             }
         } else {
-            throw  new Error('captureStream not supported for this browser');
+            throw new Error('captureStream not supported for this browser');
         }
     }
 
@@ -458,14 +458,12 @@ class RecorderModel extends widgets.DOMWidgetModel {
     updateRecord() {
         const source = this.get('stream');
         if (!source) {
-            new Error('No stream specified');
-            return;
+            throw new Error('No stream specified');
         }
 
         const mimeType = this.type + '/' + this.get('format');
         if (!MediaRecorder.isTypeSupported(mimeType)) {
-            new Error('The mimeType', mimeType, 'is not supported for record on this browser');
-            return;
+            throw new Error('The mimeType', mimeType, 'is not supported for record on this browser');
         }
 
         if (this.get('recording')) {
@@ -505,8 +503,7 @@ class RecorderModel extends widgets.DOMWidgetModel {
 
     download() {
         if (this.chunks.length === 0) {
-            new Error('Nothing to download');
-            return;
+            throw new Error('Nothing to download');
         }
         let blob = new Blob(this.chunks, {type: this.type + '/' + this.get('format')});
         let filename = this.get('filename');
@@ -636,8 +633,7 @@ export class ImageRecorderModel extends RecorderModel {
     updateRecord() {
         const source = this.get('stream');
         if (!source) {
-            new Error('No stream specified');
-            return;
+            throw new Error('No stream specified');
         }
 
         if (this.get('_data_src') !== '') {


### PR DESCRIPTION
Previously, autosave did not work unless the image/video/audio instance was set, as the observers does not trigger on initialization.