### PR TITLE
Add codecs attrbiute to video/audio recorders

### DIFF
--- a/ipywebrtc/webrtc.py
+++ b/ipywebrtc/webrtc.py
@@ -397,6 +397,9 @@ class ImageRecorder(Recorder):
 class VideoRecorder(Recorder):
     """Creates a recorder which allows to record a MediaStream widget, play the
     record in the Notebook, and download it or turn it into a Video widget.
+
+    For help on supported values for the "codecs" attribute, see
+    https://stackoverflow.com/questions/41739837/all-mime-types-supported-by-mediarecorder-in-firefox-and-chrome
     """
     _model_name = Unicode('VideoRecorderModel').tag(sync=True)
     _view_name = Unicode('VideoRecorderView').tag(sync=True)
@@ -445,6 +448,9 @@ class VideoRecorder(Recorder):
 class AudioRecorder(Recorder):
     """Creates a recorder which allows to record the Audio of a MediaStream widget, play the
     record in the Notebook, and download it or turn it into an Audio widget.
+
+    For help on supported values for the "codecs" attribute, see
+    https://stackoverflow.com/questions/41739837/all-mime-types-supported-by-mediarecorder-in-firefox-and-chrome
     """
     _model_name = Unicode('AudioRecorderModel').tag(sync=True)
     _view_name = Unicode('AudioRecorderView').tag(sync=True)

--- a/ipywebrtc/webrtc.py
+++ b/ipywebrtc/webrtc.py
@@ -402,6 +402,7 @@ class VideoRecorder(Recorder):
     _view_name = Unicode('VideoRecorderView').tag(sync=True)
 
     video = Instance(Video).tag(sync=True, **widget_serialization)
+    codecs = Unicode('', help='Optional codecs for the recording.').tag(sync=True)
 
     @traitlets.default('video')
     def _default_video(self):
@@ -449,6 +450,7 @@ class AudioRecorder(Recorder):
     _view_name = Unicode('AudioRecorderView').tag(sync=True)
 
     audio = Instance(Audio).tag(sync=True, **widget_serialization)
+    codecs = Unicode('', help='Optional codecs for the recording.').tag(sync=True)
 
     @traitlets.default('audio')
     def _default_audio(self):

--- a/ipywebrtc/webrtc.py
+++ b/ipywebrtc/webrtc.py
@@ -402,7 +402,7 @@ class VideoRecorder(Recorder):
     _view_name = Unicode('VideoRecorderView').tag(sync=True)
 
     video = Instance(Video).tag(sync=True, **widget_serialization)
-    codecs = Unicode('', help='Optional codecs for the recording.').tag(sync=True)
+    codecs = Unicode('', help='Optional codecs for the recording, e.g. "vp8" or "vp9, opus".').tag(sync=True)
 
     @traitlets.default('video')
     def _default_video(self):
@@ -450,7 +450,7 @@ class AudioRecorder(Recorder):
     _view_name = Unicode('AudioRecorderView').tag(sync=True)
 
     audio = Instance(Audio).tag(sync=True, **widget_serialization)
-    codecs = Unicode('', help='Optional codecs for the recording.').tag(sync=True)
+    codecs = Unicode('', help='Optional codecs for the recording, e.g. "opus".').tag(sync=True)
 
     @traitlets.default('audio')
     def _default_audio(self):

--- a/js/src/webrtc.js
+++ b/js/src/webrtc.js
@@ -434,6 +434,7 @@ class RecorderModel extends widgets.DOMWidgetModel {
             stream: null,
             filename: 'record',
             format: 'webm',
+            codecs: '',
             recording: false,
             _data_src: '',
          };
@@ -455,6 +456,15 @@ class RecorderModel extends widgets.DOMWidgetModel {
         }
     }
 
+    get mimeType() {
+        const codecs = this.get('codecs') || '';
+        let mimeType = `${this.type}/${this.get('format')}`;
+        if (codecs) {
+            mimeType += `; codecs="${codecs}"`;
+        }
+        return mimeType;
+    }
+
     updateRecord() {
         const source = this.get('stream');
         if (!source) {
@@ -462,7 +472,7 @@ class RecorderModel extends widgets.DOMWidgetModel {
             return;
         }
 
-        const mimeType = this.type + '/' + this.get('format');
+        const mimeType = this.mimeType;
         if (!MediaRecorder.isTypeSupported(mimeType)) {
             new Error('The mimeType', mimeType, 'is not supported for record on this browser');
             return;
@@ -508,7 +518,7 @@ class RecorderModel extends widgets.DOMWidgetModel {
             new Error('Nothing to download');
             return;
         }
-        let blob = new Blob(this.chunks, {type: this.type + '/' + this.get('format')});
+        let blob = new Blob(this.chunks, {type: this.mimeType});
         let filename = this.get('filename');
         if (filename.indexOf('.') < 0) {
           filename = this.get('filename') + '.' + this.get('format');


### PR DESCRIPTION
Allows to specify the codecs parameter to the mime type. While allowing to pick both audio and video codec, this is maybe most useful for the video codec, where the default video codec on chrome cannot be played on firefox (chrome defaults to h264, which is non-standard, [ref](https://bugzilla.mozilla.org/show_bug.cgi?id=1374026)). We should also consider setting the default codecs for video to `'vp8'` or `'vp9'` for this reason.