### PR TITLE
Handle remove call multiple times

### DIFF
--- a/js/src/webrtc.js
+++ b/js/src/webrtc.js
@@ -45,7 +45,7 @@ export class MediaStreamView extends widgets.DOMWidgetView {
         this.video.controls = true;
         this.pWidget.addClass('jupyter-widgets');
         this.pWidget.addClass('widget-image');
-        
+
         this.initPromise = this.model.captureStream();
 
         this.initPromise.then((stream) => {
@@ -60,6 +60,10 @@ export class MediaStreamView extends widgets.DOMWidgetView {
     }
 
     remove() {
+        if (this.initPromise === null) {
+            // Remove already called
+            return;
+        }
         this.initPromise.then((stream) => {
             this.video.pause();
             this.video.srcObject = null;


### PR DESCRIPTION
If remove is called multiple times without an intermediate render() call, ignore the redundant calls.

Follow up to #34.