### PR TITLE
Update README installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To install:
 
 ```
 $ pip install ipywebrtc                             # will auto enable for notebook >= 5.3
-$ jupyter labextension install jupyter-webrtc       # for jupyter lab
+$ jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-webrtc       # for jupyter lab
 ```
 
 For a development installation (requires npm),


### PR DESCRIPTION
Users cannot know they need to install the widgets labextension if
that's the first widgets extension they install