### PR TITLE
DOC: Remove jupyter_sphinx dependency

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,7 +3,6 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-- jupyter_sphinx
 - ipywidgets
 - nbformat
 - nbsphinx

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,7 +35,6 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
-    'jupyter_sphinx.embed_widgets',
 	'nbsphinx',
     ]
 

--- a/requirements_rtd.txt
+++ b/requirements_rtd.txt
@@ -1,5 +1,3 @@
-#jupyter_sphinx>=0.1.1
-git+https://github.com/maartenbreddels/jupyter-sphinx@ipywidgets7require_c
 ipywebrtc==0.3.0
 ipywidgets>=7.4.0
 traitlets


### PR DESCRIPTION
This broke the last few RTD builds (https://readthedocs.org/projects/ipywebrtc/builds/) and it is not necessary anymore since `nbsphinx` supports widgets by default.

See #53.